### PR TITLE
Changed deprecated String::from_str to String::from

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -666,7 +666,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
 
     // Write debugger script:
     // We don't want to hang when calling `quit` while the process is still running
-    let mut script_str = String::from_str("settings set auto-confirm true\n");
+    let mut script_str = String::from("settings set auto-confirm true\n");
 
     // Make LLDB emit its version, so we have it documented in the test output
     script_str.push_str("version\n");


### PR DESCRIPTION
This is breaking our rust-clippy build on current nightly.

It's just a one liner to make review easy :smile: