### PR TITLE
improvements suggested by clippy

### DIFF
--- a/src/compiletest.rs
+++ b/src/compiletest.rs
@@ -93,14 +93,11 @@ pub fn run_tests(config: &Config) {
         env::set_var("RUST_TEST_TASKS","1");
     }
 
-    match config.mode {
-        DebugInfoLldb => {
-            // Some older versions of LLDB seem to have problems with multiple
-            // instances running in parallel, so only run one test task at a
-            // time.
-            env::set_var("RUST_TEST_TASKS", "1");
-        }
-        _ => { /* proceed */ }
+    if let DebugInfoLldb = config.mode {
+        // Some older versions of LLDB seem to have problems with multiple
+        // instances running in parallel, so only run one test task at a
+        // time.
+        env::set_var("RUST_TEST_TASKS", "1");
     }
 
     let opts = test_opts(config);
@@ -264,7 +261,7 @@ fn extract_lldb_version(full_version_line: Option<String>) -> Option<String> {
 
     match full_version_line {
         Some(ref full_version_line)
-          if full_version_line.trim().len() > 0 => {
+          if !full_version_line.trim().is_empty() => {
             let full_version_line = full_version_line.trim();
 
             for (pos, l) in full_version_line.char_indices() {
@@ -282,7 +279,7 @@ fn extract_lldb_version(full_version_line: Option<String>) -> Option<String> {
                 let vers = full_version_line[pos + 5..].chars().take_while(|c| {
                     c.is_digit(10)
                 }).collect::<String>();
-                if vers.len() > 0 { return Some(vers) }
+                if !vers.is_empty() { return Some(vers) }
             }
             println!("Could not extract LLDB version from line '{}'",
                      full_version_line);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,15 +68,14 @@ fn parse_expected(last_nonfollow_error: Option<usize>,
         (false, line[start + 3..].chars().take_while(|c| *c == '^').count())
     };
     let kind_start = start + 3 + adjusts + (follow as usize);
-    let letters = line[kind_start..].chars();
-    let kind = letters.skip_while(|c| c.is_whitespace())
+    let kind = line[kind_start..].chars().skip_while(|c| c.is_whitespace())
                       .take_while(|c| !c.is_whitespace())
                       .flat_map(|c| c.to_lowercase())
                       .collect::<String>();
     let letters = line[kind_start..].chars();
     let msg = letters.skip_while(|c| c.is_whitespace())
                      .skip_while(|c| !c.is_whitespace())
-                     .collect::<String>().trim().to_string();
+                     .collect::<String>().trim().to_owned();
 
     let (which, line) = if follow {
         assert!(adjusts == 0, "use either //~| or //~^, not both.");

--- a/src/header.rs
+++ b/src/header.rs
@@ -129,8 +129,8 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
     for key in vec!["RUST_TEST_NOCAPTURE", "RUST_TEST_TASKS"] {
         if let Ok(val) = env::var(key) {
-            if exec_env.iter().find(|&&(ref x, _)| *x == key.to_string()).is_none() {
-                    exec_env.push((key.to_string(), val))
+            if exec_env.iter().find(|&&(ref x, _)| *x == key).is_none() {
+                    exec_env.push((key.to_owned(), val))
             }
         }
     }
@@ -147,7 +147,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
         check_stdout: check_stdout,
         no_prefer_dynamic: no_prefer_dynamic,
         no_pretty_expanded: no_pretty_expanded,
-        pretty_mode: pretty_mode.unwrap_or("normal".to_string()),
+        pretty_mode: pretty_mode.unwrap_or("normal".to_owned()),
         pretty_compare_only: pretty_compare_only,
         forbid_output: forbid_output,
     }
@@ -299,11 +299,11 @@ fn parse_exec_env(line: &str) -> Option<(String, String)> {
         // nv is either FOO or FOO=BAR
         let mut strs: Vec<String> = nv
             .splitn(1, '=')
-            .map(|s| s.to_string())
+            .map(|s| s.to_owned())
             .collect();
 
         match strs.len() {
-            1 => (strs.pop().unwrap(), "".to_string()),
+            1 => (strs.pop().unwrap(), "".to_owned()),
             2 => {
                 let end = strs.pop().unwrap();
                 (strs.pop().unwrap(), end)
@@ -318,7 +318,7 @@ fn parse_pp_exact(line: &str, testfile: &Path) -> Option<PathBuf> {
         Some(s) => Some(PathBuf::from(&s)),
         None => {
             if parse_name_directive(line, "pp-exact") {
-                testfile.file_name().map(|s| PathBuf::from(s))
+                testfile.file_name().map(PathBuf::from)
             } else {
                 None
             }
@@ -333,7 +333,7 @@ fn parse_name_directive(line: &str, directive: &str) -> bool {
 pub fn parse_name_value_directive(line: &str, directive: &str) -> Option<String> {
     let keycolon = format!("{}:", directive);
     if let Some(colon) = line.find(&keycolon) {
-        let value = line[(colon + keycolon.len()) .. line.len()].to_string();
+        let value = line[(colon + keycolon.len()) .. line.len()].to_owned();
         debug!("{}: {}", directive, value);
         Some(value)
     } else {

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -186,9 +186,9 @@ fn run_valgrind_test(config: &Config, props: &TestProps, testfile: &Path) {
 
 fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
     if props.pp_exact.is_some() {
-        logv(config, "testing for exact pretty-printing".to_string());
+        logv(config, "testing for exact pretty-printing".to_owned());
     } else {
-        logv(config, "testing for converging pretty-printing".to_string());
+        logv(config, "testing for converging pretty-printing".to_owned());
     }
 
     let rounds =
@@ -204,7 +204,7 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
         let proc_res = print_source(config,
                                     props,
                                     testfile,
-                                    srcs[round].to_string(),
+                                    srcs[round].to_owned(),
                                     &props.pretty_mode);
 
         if !proc_res.status.success() {
@@ -230,9 +230,9 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
 
     if props.pp_exact.is_some() {
         // Now we have to care about line endings
-        let cr = "\r".to_string();
-        actual = actual.replace(&cr, "").to_string();
-        expected = expected.replace(&cr, "").to_string();
+        let cr = "\r".to_owned();
+        actual = actual.replace(&cr, "").to_owned();
+        expected = expected.replace(&cr, "").to_owned();
     }
 
     compare_source(&expected, &actual);
@@ -274,7 +274,7 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
                         make_pp_args(config,
                                      props,
                                      testfile,
-                                     pretty_type.to_string()),
+                                     pretty_type.to_owned()),
                         props.exec_env.clone(),
                         &config.compile_lib_path,
                         Some(aux_dir.to_str().unwrap()),
@@ -287,17 +287,17 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
                     pretty_type: String) -> ProcArgs {
         let aux_dir = aux_output_dir_name(config, testfile);
         // FIXME (#9639): This needs to handle non-utf8 paths
-        let mut args = vec!("-".to_string(),
-                            "-Zunstable-options".to_string(),
-                            "--pretty".to_string(),
+        let mut args = vec!("-".to_owned(),
+                            "-Zunstable-options".to_owned(),
+                            "--pretty".to_owned(),
                             pretty_type,
                             format!("--target={}", config.target),
-                            "-L".to_string(),
-                            aux_dir.to_str().unwrap().to_string());
+                            "-L".to_owned(),
+                            aux_dir.to_str().unwrap().to_owned());
         args.extend(split_maybe_args(&config.target_rustcflags).into_iter());
         args.extend(split_maybe_args(&props.compile_flags).into_iter());
         ProcArgs {
-            prog: config.rustc_path.to_str().unwrap().to_string(),
+            prog: config.rustc_path.to_str().unwrap().to_owned(),
             args: args,
         }
     }
@@ -334,19 +334,19 @@ actual:\n\
             &*config.target
         };
         // FIXME (#9639): This needs to handle non-utf8 paths
-        let mut args = vec!("-".to_string(),
-                            "-Zno-trans".to_string(),
-                            "--crate-type=lib".to_string(),
+        let mut args = vec!("-".to_owned(),
+                            "-Zno-trans".to_owned(),
+                            "--crate-type=lib".to_owned(),
                             format!("--target={}", target),
-                            "-L".to_string(),
-                            config.build_base.to_str().unwrap().to_string(),
-                            "-L".to_string(),
-                            aux_dir.to_str().unwrap().to_string());
+                            "-L".to_owned(),
+                            config.build_base.to_str().unwrap().to_owned(),
+                            "-L".to_owned(),
+                            aux_dir.to_str().unwrap().to_owned());
         args.extend(split_maybe_args(&config.target_rustcflags).into_iter());
         args.extend(split_maybe_args(&props.compile_flags).into_iter());
         // FIXME (#9639): This needs to handle non-utf8 paths
         ProcArgs {
-            prog: config.rustc_path.to_str().unwrap().to_string(),
+            prog: config.rustc_path.to_str().unwrap().to_owned(),
             args: args,
         }
     }
@@ -393,7 +393,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
             script_str.push_str(&format!("set solib-search-path \
                                          ./{}/stage2/lib/rustlib/{}/lib/\n",
                                          config.host, config.target));
-            for line in breakpoint_lines.iter() {
+            for line in &breakpoint_lines {
                 script_str.push_str(&format!("break {:?}:{}\n",
                                              testfile.file_name().unwrap()
                                                      .to_string_lossy(),
@@ -413,24 +413,24 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                          &android_config.adb_path,
                          None,
                          &[
-                            "push".to_string(),
-                            exe_file.to_str().unwrap().to_string(),
+                            "push".to_owned(),
+                            exe_file.to_str().unwrap().to_owned(),
                             android_config.adb_test_dir.clone()
                          ],
-                         vec!(("".to_string(), "".to_string())),
-                         Some("".to_string()))
+                         vec!(("".to_owned(), "".to_owned())),
+                         Some("".to_owned()))
                 .expect(&format!("failed to exec `{:?}`", android_config.adb_path));
 
             procsrv::run("",
                          &android_config.adb_path,
                          None,
                          &[
-                            "forward".to_string(),
-                            "tcp:5039".to_string(),
-                            "tcp:5039".to_string()
+                            "forward".to_owned(),
+                            "tcp:5039".to_owned(),
+                            "tcp:5039".to_owned()
                          ],
-                         vec!(("".to_string(), "".to_string())),
-                         Some("".to_string()))
+                         vec!(("".to_owned(), "".to_owned())),
+                         Some("".to_owned()))
                 .expect(&format!("failed to exec `{:?}`", android_config.adb_path));
 
             let adb_arg = format!("export LD_LIBRARY_PATH={}; \
@@ -447,12 +447,12 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                                                             ,
                                                       None,
                                                       &[
-                                                        "shell".to_string(),
+                                                        "shell".to_owned(),
                                                         adb_arg.clone()
                                                       ],
-                                                      vec!(("".to_string(),
-                                                            "".to_string())),
-                                                      Some("".to_string()))
+                                                      vec!(("".to_owned(),
+                                                            "".to_owned())),
+                                                      Some("".to_owned()))
                 .expect(&format!("failed to exec `{:?}`", android_config.adb_path));
             loop {
                 //waiting 1 second for gdbserver start
@@ -467,16 +467,16 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
 
             //let android_config = config.android.unwrap();
             let tool_path = match android_config.android_cross_path.to_str() {
-                Some(x) => x.to_string(),
+                Some(x) => x.to_owned(),
                 None => fatal("cannot find android cross path")
             };
 
             let debugger_script = make_out_name(config, testfile, "debugger.script");
             // FIXME (#9639): This needs to handle non-utf8 paths
             let debugger_opts =
-                vec!("-quiet".to_string(),
-                     "-batch".to_string(),
-                     "-nx".to_string(),
+                vec!("-quiet".to_owned(),
+                     "-batch".to_owned(),
+                     "-nx".to_owned(),
                      format!("-command={}", debugger_script.to_str().unwrap()));
 
             let mut gdb_path = tool_path;
@@ -489,7 +489,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                              &gdb_path,
                              None,
                              &debugger_opts,
-                             vec!(("".to_string(), "".to_string())),
+                             vec!(("".to_owned(), "".to_owned())),
                              None)
                 .expect(&format!("failed to exec `{:?}`", gdb_path));
             let cmdline = {
@@ -518,7 +518,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
             let rust_pp_module_abs_path = rust_src_root.join(rust_pp_module_rel_path)
                                                        .to_str()
                                                        .unwrap()
-                                                       .to_string();
+                                                       .to_owned();
             // write debugger script
             let mut script_str = String::with_capacity(2048);
 
@@ -585,17 +585,17 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
 
             // FIXME (#9639): This needs to handle non-utf8 paths
             let debugger_opts =
-                vec!("-quiet".to_string(),
-                     "-batch".to_string(),
-                     "-nx".to_string(),
+                vec!("-quiet".to_owned(),
+                     "-batch".to_owned(),
+                     "-nx".to_owned(),
                      format!("-command={}", debugger_script.to_str().unwrap()));
 
             let proc_args = ProcArgs {
-                prog: debugger().to_string(),
+                prog: debugger().to_owned(),
                 args: debugger_opts,
             };
 
-            let environment = vec![("PYTHONPATH".to_string(), rust_pp_module_abs_path)];
+            let environment = vec![("PYTHONPATH".to_owned(), rust_pp_module_abs_path)];
 
             debugger_run_result = compose_and_run(config,
                                                   testfile,
@@ -678,7 +678,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
     let rust_pp_module_abs_path = rust_src_root.join(rust_pp_module_rel_path)
                                                .to_str()
                                                .unwrap()
-                                               .to_string();
+                                               .to_owned();
 
     script_str.push_str(&format!("command script import {}\n",
                                  &rust_pp_module_abs_path[..])[..]);
@@ -813,9 +813,9 @@ fn cleanup_debug_info_options(options: &Option<String>) -> Option<String> {
 
     // Remove options that are either unwanted (-O) or may lead to duplicates due to RUSTFLAGS.
     let options_to_remove = [
-        "-O".to_string(),
-        "-g".to_string(),
-        "--debuginfo".to_string()
+        "-O".to_owned(),
+        "-g".to_owned(),
+        "--debuginfo".to_owned()
     ];
     let new_options =
         split_maybe_args(options).into_iter()
@@ -835,7 +835,7 @@ fn check_debugger_output(debugger_run_result: &ProcRes, check_lines: &[String]) 
                 s
                  .trim()
                  .split("[...]")
-                 .map(|x| x.to_string())
+                 .map(str::to_owned)
                  .collect()
             }).collect();
         // check if each line in props.check_lines appears in the
@@ -1142,15 +1142,15 @@ fn compile_test(config: &Config, props: &TestProps,
 }
 
 fn jit_test(config: &Config, props: &TestProps, testfile: &Path) -> ProcRes {
-    compile_test_(config, props, testfile, &["--jit".to_string()])
+    compile_test_(config, props, testfile, &["--jit".to_owned()])
 }
 
 fn compile_test_(config: &Config, props: &TestProps,
                  testfile: &Path, extra_args: &[String]) -> ProcRes {
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let mut link_args = vec!("-L".to_string(),
-                             aux_dir.to_str().unwrap().to_string());
+    let mut link_args = vec!("-L".to_owned(),
+                             aux_dir.to_str().unwrap().to_owned());
     link_args.extend(extra_args.iter().cloned());
     let args = make_compile_args(config,
                                  props,
@@ -1196,7 +1196,7 @@ fn compose_and_run_compiler(
 
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let extra_link_args = vec!("-L".to_string(), aux_dir.to_str().unwrap().to_string());
+    let extra_link_args = vec!("-L".to_owned(), aux_dir.to_str().unwrap().to_owned());
 
     for rel_ab in &props.aux_builds {
         let abs_ab = match config.aux_base {
@@ -1207,7 +1207,7 @@ fn compose_and_run_compiler(
         let mut crate_type = if aux_props.no_prefer_dynamic {
             Vec::new()
         } else {
-            vec!("--crate-type=dylib".to_string())
+            vec!("--crate-type=dylib".to_owned())
         };
         crate_type.extend(extra_link_args.clone().into_iter());
         let aux_args =
@@ -1286,26 +1286,26 @@ fn make_compile_args<F>(config: &Config,
         &*config.target
     };
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let mut args = vec!(testfile.to_str().unwrap().to_string(),
-                        "-L".to_string(),
-                        config.build_base.to_str().unwrap().to_string(),
+    let mut args = vec!(testfile.to_str().unwrap().to_owned(),
+                        "-L".to_owned(),
+                        config.build_base.to_str().unwrap().to_owned(),
                         format!("--target={}", target));
     args.push_all(&extras);
     if !props.no_prefer_dynamic {
-        args.push("-C".to_string());
-        args.push("prefer-dynamic".to_string());
+        args.push("-C".to_owned());
+        args.push("prefer-dynamic".to_owned());
     }
     let path = match xform_file {
         TargetLocation::ThisFile(path) => {
-            args.push("-o".to_string());
+            args.push("-o".to_owned());
             path
         }
         TargetLocation::ThisDirectory(path) => {
-            args.push("--out-dir".to_string());
+            args.push("--out-dir".to_owned());
             path
         }
     };
-    args.push(path.to_str().unwrap().to_string());
+    args.push(path.to_str().unwrap().to_owned());
     if props.force_host {
         args.extend(split_maybe_args(&config.host_rustcflags).into_iter());
     } else {
@@ -1313,7 +1313,7 @@ fn make_compile_args<F>(config: &Config,
     }
     args.extend(split_maybe_args(&props.compile_flags).into_iter());
     ProcArgs {
-        prog: config.rustc_path.to_str().unwrap().to_string(),
+        prog: config.rustc_path.to_str().unwrap().to_owned(),
         args: args,
     }
 }
@@ -1342,7 +1342,7 @@ fn make_run_args(config: &Config, props: &TestProps, testfile: &Path) -> ProcArg
     let exe_file = make_exe_name(config, testfile);
 
     // FIXME (#9639): This needs to handle non-utf8 paths
-    args.push(exe_file.to_str().unwrap().to_string());
+    args.push(exe_file.to_str().unwrap().to_owned());
 
     // Add the arguments in the run_flags directive
     args.extend(split_maybe_args(&props.run_flags).into_iter());
@@ -1363,7 +1363,7 @@ fn split_maybe_args(argstr: &Option<String>) -> Vec<String> {
                  if s.chars().all(|c| c.is_whitespace()) {
                      None
                  } else {
-                     Some(s.to_string())
+                     Some(s.to_owned())
                  }
              }).collect()
         }
@@ -1494,15 +1494,12 @@ fn _arm_exec_compiled_test(config: &Config,
     let cmdline = make_cmdline("",
                                &args.prog,
                                &args.args);
-    let android_config = match config.android {
-        Some(ref c) => c,
-        None => panic!("No android config found")
-    };
+    let android_config = config.android.as_ref().expect("No android config found");
 
     // get bare program string
     let mut tvec: Vec<String> = args.prog
                                     .split('/')
-                                    .map(|ts| ts.to_string())
+                                    .map(|ts| ts.to_owned())
                                     .collect();
     let prog_short = tvec.pop().unwrap();
 
@@ -1511,12 +1508,12 @@ fn _arm_exec_compiled_test(config: &Config,
                                    &android_config.adb_path,
                                    None,
                                    &[
-                                    "push".to_string(),
+                                    "push".to_owned(),
                                     args.prog.clone(),
                                     android_config.adb_test_dir.clone()
                                    ],
-                                   vec!(("".to_string(), "".to_string())),
-                                   Some("".to_string()))
+                                   vec!(("".to_owned(), "".to_owned())),
+                                   Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", android_config.adb_path));
 
     if config.verbose {
@@ -1532,7 +1529,7 @@ fn _arm_exec_compiled_test(config: &Config,
     let mut runargs = Vec::new();
 
     // run test via adb_run_wrapper
-    runargs.push("shell".to_string());
+    runargs.push("shell".to_owned());
     for (key, val) in env {
         runargs.push(format!("{}={}", key, val));
     }
@@ -1541,19 +1538,19 @@ fn _arm_exec_compiled_test(config: &Config,
     runargs.push(format!("{}", prog_short));
 
     for tv in &args.args {
-        runargs.push(tv.to_string());
+        runargs.push(tv.to_owned());
     }
     procsrv::run("",
                  &android_config.adb_path,
                  None,
                  &runargs,
-                 vec!(("".to_string(), "".to_string())), Some("".to_string()))
+                 vec!(("".to_owned(), "".to_owned())), Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", android_config.adb_path));
 
     // get exitcode of result
     runargs = Vec::new();
-    runargs.push("shell".to_string());
-    runargs.push("cat".to_string());
+    runargs.push("shell".to_owned());
+    runargs.push("cat".to_owned());
     runargs.push(format!("{}/{}.exitcode", android_config.adb_test_dir, prog_short));
 
     let procsrv::Result{ out: exitcode_out, err: _, status: _ } =
@@ -1561,8 +1558,8 @@ fn _arm_exec_compiled_test(config: &Config,
                      &android_config.adb_path,
                      None,
                      &runargs,
-                     vec!(("".to_string(), "".to_string())),
-                     Some("".to_string()))
+                     vec!(("".to_owned(), "".to_owned())),
+                     Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", android_config.adb_path));
 
     let mut exitcode: i32 = 0;
@@ -1576,8 +1573,8 @@ fn _arm_exec_compiled_test(config: &Config,
 
     // get stdout of result
     runargs = Vec::new();
-    runargs.push("shell".to_string());
-    runargs.push("cat".to_string());
+    runargs.push("shell".to_owned());
+    runargs.push("cat".to_owned());
     runargs.push(format!("{}/{}.stdout", android_config.adb_test_dir, prog_short));
 
     let procsrv::Result{ out: stdout_out, err: _, status: _ } =
@@ -1585,14 +1582,14 @@ fn _arm_exec_compiled_test(config: &Config,
                      &android_config.adb_path,
                      None,
                      &runargs,
-                     vec!(("".to_string(), "".to_string())),
-                     Some("".to_string()))
+                     vec!(("".to_owned(), "".to_owned())),
+                     Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", android_config.adb_path));
 
     // get stderr of result
     runargs = Vec::new();
-    runargs.push("shell".to_string());
-    runargs.push("cat".to_string());
+    runargs.push("shell".to_owned());
+    runargs.push("cat".to_owned());
     runargs.push(format!("{}/{}.stderr", android_config.adb_test_dir, prog_short));
 
     let procsrv::Result{ out: stderr_out, err: _, status: _ } =
@@ -1600,8 +1597,8 @@ fn _arm_exec_compiled_test(config: &Config,
                      &android_config.adb_path,
                      None,
                      &runargs,
-                     vec!(("".to_string(), "".to_string())),
-                     Some("".to_string()))
+                     vec!(("".to_owned(), "".to_owned())),
+                     Some("".to_owned()))
         .expect(&format!("failed to exec `{}`", android_config.adb_path));
 
     dump_output(config,
@@ -1634,15 +1631,15 @@ fn _arm_push_aux_shared_library(config: &Config, testfile: &Path) {
                                            &android_config.adb_path,
                                            None,
                                            &[
-                                            "push".to_string(),
+                                            "push".to_owned(),
                                             file.to_str()
                                                 .unwrap()
-                                                .to_string(),
-                                            android_config.adb_test_dir.to_string(),
+                                                .to_owned(),
+                                            android_config.adb_test_dir.to_owned(),
                                            ],
-                                           vec!(("".to_string(),
-                                                 "".to_string())),
-                                           Some("".to_string()))
+                                           vec!(("".to_owned(),
+                                                 "".to_owned())),
+                                           Some("".to_owned()))
                 .expect(&format!("failed to exec `{}`", android_config.adb_path));
 
             if config.verbose {
@@ -1671,10 +1668,10 @@ fn compile_test_and_save_bitcode(config: &Config, props: &TestProps,
                                  testfile: &Path) -> ProcRes {
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let mut link_args = vec!("-L".to_string(),
-                             aux_dir.to_str().unwrap().to_string());
-    let llvm_args = vec!("--emit=llvm-bc,obj".to_string(),
-                         "--crate-type=lib".to_string());
+    let mut link_args = vec!("-L".to_owned(),
+                             aux_dir.to_str().unwrap().to_owned());
+    let llvm_args = vec!("--emit=llvm-bc,obj".to_owned(),
+                         "--crate-type=lib".to_owned());
     link_args.extend(llvm_args.into_iter());
     let args = make_compile_args(config,
                                  props,
@@ -1693,12 +1690,12 @@ fn compile_cc_with_clang_and_save_bitcode(config: &Config, _props: &TestProps,
     let testcc = testfile.with_extension("cc");
     let proc_args = ProcArgs {
         // FIXME (#9639): This needs to handle non-utf8 paths
-        prog: config.clang_path.as_ref().unwrap().to_str().unwrap().to_string(),
-        args: vec!("-c".to_string(),
-                   "-emit-llvm".to_string(),
-                   "-o".to_string(),
-                   bitcodefile.to_str().unwrap().to_string(),
-                   testcc.to_str().unwrap().to_string())
+        prog: config.clang_path.as_ref().unwrap().to_str().unwrap().to_owned(),
+        args: vec!("-c".to_owned(),
+                   "-emit-llvm".to_owned(),
+                   "-o".to_owned(),
+                   bitcodefile.to_str().unwrap().to_owned(),
+                   testcc.to_str().unwrap().to_owned())
     };
     compose_and_run(config, testfile, proc_args, Vec::new(), "", None, None)
 }
@@ -1712,10 +1709,10 @@ fn extract_function_from_bitcode(config: &Config, _props: &TestProps,
     let prog = config.llvm_bin_path.as_ref().unwrap().join("llvm-extract");
     let proc_args = ProcArgs {
         // FIXME (#9639): This needs to handle non-utf8 paths
-        prog: prog.to_str().unwrap().to_string(),
+        prog: prog.to_str().unwrap().to_owned(),
         args: vec!(format!("-func={}", fname),
                    format!("-o={}", extracted_bc.to_str().unwrap()),
-                   bitcodefile.to_str().unwrap().to_string())
+                   bitcodefile.to_str().unwrap().to_owned())
     };
     compose_and_run(config, testfile, proc_args, Vec::new(), "", None, None)
 }
@@ -1729,9 +1726,9 @@ fn disassemble_extract(config: &Config, _props: &TestProps,
     let prog = config.llvm_bin_path.as_ref().unwrap().join("llvm-dis");
     let proc_args = ProcArgs {
         // FIXME (#9639): This needs to handle non-utf8 paths
-        prog: prog.to_str().unwrap().to_string(),
+        prog: prog.to_str().unwrap().to_owned(),
         args: vec!(format!("-o={}", extracted_ll.to_str().unwrap()),
-                   extracted_bc.to_str().unwrap().to_string())
+                   extracted_bc.to_str().unwrap().to_owned())
     };
     compose_and_run(config, testfile, proc_args, Vec::new(), "", None, None)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -42,7 +42,7 @@ pub fn make_new_path(path: &str) -> String {
         Ok(curr) => {
             format!("{}{}{}", path, path_div(), curr)
         }
-        Err(..) => path.to_string()
+        Err(..) => path.to_owned()
     }
 }
 


### PR DESCRIPTION
I changed a lot of `.to_string()` that can be better written as `.to_owned()`, and removed some redundant closures.

I also note that there is quite a bit of shadowing; however there are some false positives (because I've yet to support more destructuring patterns), so I've disabled that lint for now.