### PR TITLE
Adjust for Stable features lint

### DIFF
--- a/src/compiletest.rs
+++ b/src/compiletest.rs
@@ -15,7 +15,6 @@
 #![feature(str_char)]
 #![feature(dynamic_lib)]
 
-#![deny(warnings)]
 #![deny(unused_imports)]
 
 extern crate test;

--- a/src/compiletest.rs
+++ b/src/compiletest.rs
@@ -12,7 +12,6 @@
 
 #![feature(rustc_private)]
 #![feature(test)]
-#![feature(path_ext)]
 #![feature(str_char)]
 #![feature(dynamic_lib)]
 


### PR DESCRIPTION
Deny warnings doesn't seem very future-proofed, perhaps you want to `deny(warnings)` specifically on travis or something via `cargo rustc -- -F warnings`? 

For reference, this killed the nickel build when `cargo doc` was being run.