### PR TITLE
Rustup to *rustc 1.14.0-nightly (86affcdf6 2016-09-28)*

### DIFF
--- a/src/compiletest.rs
+++ b/src/compiletest.rs
@@ -138,6 +138,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         },
         color: test::AutoColor,
         test_threads: None,
+        skip: vec![],
     }
 }
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/36604.

This will need to be published.