### PR TITLE
Fix test-project tests

### DIFF
--- a/test-project/tests/compile-fail/trait-bounds-cant-coerce.rs
+++ b/test-project/tests/compile-fail/trait-bounds-cant-coerce.rs
@@ -22,9 +22,9 @@ fn c(x: Box<Foo+Sync+Send>) {
 
 fn d(x: Box<Foo>) {
     a(x); //~  ERROR mismatched types
-          //~| expected type `Box<Foo + Send + 'static>`
-          //~| found type `Box<Foo + 'static>`
-          //~| expected bounds `Send`, found no bounds
+          //~| expected trait `Foo + std::marker::Send`, found trait `Foo`
+          //~| expected type `std::boxed::Box<Foo + std::marker::Send + 'static>`
+          //~| found type `std::boxed::Box<Foo + 'static>`
 }
 
 fn main() { }


### PR DESCRIPTION
Now runs on `rustc 1.17.0-nightly (b1e31766d 2017-03-03)`