### PR TITLE
io error message in `make_tests`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ pub fn make_tests(config: &Config) -> Vec<test::TestDescAndFn> {
                            &config.src_base,
                            &PathBuf::new(),
                            &mut tests)
-        .unwrap();
+        .expect(&format!("Could not read tests from {}", config.src_base.display()));
     tests
 }
 


### PR DESCRIPTION
This would have helped me to understand a broken configuration more quickly. I had compiletest set up to look for a couple of directories, but one was missing and it took me a while to figure it out.