### PR TITLE
Upgrade to rustc 1.19.0-nightly (ced823e26 2017-05-07)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletest_rs"
-version = "0.2.5"
+version = "0.2.6"
 authors = [ "The Rust Project Developers"
           , "Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>"
           , "Manish Goregaokar <manishsmail@gmail.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         test_threads: None,
         skip: vec![],
         list: false,
+        options: test::Options::new(),
     }
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/41678 has a breaking change, which as of this writing has not reached the Nightly channel yet.