### PR TITLE
update for new TestDesc::allow_fail field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,7 @@ pub fn make_test(config: &Config, testpaths: &TestPaths) -> test::TestDescAndFn 
             name: make_test_name(config, testpaths),
             ignore: early_props.ignore,
             should_panic: should_panic,
+            allow_fail: false,
         },
         testfn: make_test_closure(config, testpaths),
     }


### PR DESCRIPTION
Fixes breakage introduced by https://github.com/rust-lang/rust/pull/42219.