### PR TITLE
fix regression on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,11 +269,15 @@ pub fn make_test(config: &Config, testpaths: &TestPaths) -> test::TestDescAndFn 
         }
     };
 
+    // Always fail for now.
+    let allow_fail = false;
+
     test::TestDescAndFn {
         desc: test::TestDesc {
             name: make_test_name(config, testpaths),
             ignore: early_props.ignore,
             should_panic: should_panic,
+            allow_fail: allow_fail,
         },
         testfn: make_test_closure(config, testpaths),
     }


### PR DESCRIPTION
missing field `allow_fail` in initializer of `test::TestDesc`

This was added on 2017-05-24 via
https://github.com/rust-lang/rust/commit/60dd83ea85853f6a31f8998eb80ce47446fdb785