### PR TITLE
Made ConfigBuilder pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletest_rs"
-version = "0.3.0"
+version = "0.2.9"
 authors = [ "The Rust Project Developers"
           , "Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>"
           , "Manish Goregaokar <manishsmail@gmail.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletest_rs"
-version = "0.2.8"
+version = "0.3.0"
 authors = [ "The Rust Project Developers"
           , "Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>"
           , "Manish Goregaokar <manishsmail@gmail.com>"

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,7 +11,6 @@ pub use self::Mode::*;
 
 use std::env;
 use std::fmt;
-use std::mem;
 use std::str::FromStr;
 use std::path::PathBuf;
 use rustc;
@@ -193,18 +192,13 @@ pub struct Config {
 }
 
 impl Config {
-
     /// Add rustc flags to link with the crate's dependencies in addition to the crate itself
     pub fn link_deps(&mut self) {
-        // The linked library path env var name depends on the target OS. I'm not certain if this
-        // covers all the cases adequately.
-        let (varname, path_delim) = if cfg!(any(target_os = "macos", target_os = "ios")) {
-            ("DYLD_LIBRARY_PATH", ":")
-        } else if cfg!(target_os = "windows") {
-            ("PATH", ";")
-        } else {
-            ("LD_LIBRARY_PATH", ":")
-        };
+        // The linked library path env var name depends on the target OS. Code copied from
+        // https://github.com/rust-lang/cargo/blob/master/src/cargo/util/paths.rs#L22-L26
+        let varname = if cfg!(windows) { "PATH" }
+                      else if cfg!(target_os = "macos") { "DYLD_LIBRARY_PATH" }
+                      else { "LD_LIBRARY_PATH" };
 
         // Dependencies can be found in the environment variable. Throw everything there into the
         // link flags
@@ -212,13 +206,11 @@ impl Config {
             panic!("Cannot link to dependencies. Problem with env var '{}': {:?}", varname, e)
         });
 
-        // Move the flags out so we can mutate them and put them back in
-        let flags_opt = mem::replace(&mut self.target_rustcflags, None);
-
         // Append to current flags if any are set, otherwise make new String
-        let mut flags = flags_opt.unwrap_or(String::new());
-        for p in lib_paths.split(path_delim) {
-            flags += &*format!(" -L {} ", p);
+        let mut flags = self.target_rustcflags.take().unwrap_or_else(String::new);
+        for p in env::split_paths(&lib_paths) {
+            flags += " -L ";
+            flags += p.to_str().unwrap(); // Can't fail. We already know this is unicode
         }
 
         self.target_rustcflags = Some(flags);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@ use common::{Config, Mode};
 use common::{Pretty, DebugInfoGdb, DebugInfoLldb};
 use test::TestPaths;
 use std::borrow::ToOwned;
-use rustc::session::config::host_triple;
 
 use self::header::EarlyProps;
 
@@ -44,47 +43,10 @@ pub mod runtest;
 pub mod common;
 pub mod errors;
 
+pub use common::ConfigBuilder;
+
 pub fn default_config() -> Config {
-    Config {
-        compile_lib_path: PathBuf::from(""),
-        run_lib_path: PathBuf::from(""),
-        rustc_path: PathBuf::from("rustc"),
-        rustdoc_path: PathBuf::from("rustdoc-path"),
-        lldb_python: "python".to_owned(),
-        docck_python: "docck-python".to_owned(),
-        valgrind_path: None,
-        force_valgrind: false,
-        llvm_filecheck: None,
-        src_base: PathBuf::from("tests/run-pass"),
-        build_base: env::temp_dir(),
-        stage_id: "stage-id".to_owned(),
-        mode: Mode::RunPass,
-        run_ignored: false,
-        filter: None,
-        filter_exact: false,
-        logfile: None,
-        runtool: None,
-        host_rustcflags: None,
-        target_rustcflags: None,
-        target: host_triple().to_owned(),
-        host: host_triple().to_owned(),
-        gdb_version: None,
-        lldb_version: None,
-        llvm_version: None,
-        android_cross_path: PathBuf::from("android-cross-path"),
-        adb_path: "adb-path".to_owned(),
-        adb_test_dir: "adb-test-dir/target".to_owned(),
-        adb_device_status: false,
-        lldb_python_dir: None,
-        verbose: false,
-        quiet: false,
-        cc: "cc".to_string(),
-        cxx: "cxx".to_string(),
-        cflags: "cflags".to_string(),
-        llvm_components: "llvm-components".to_string(),
-        llvm_cxxflags: "llvm-cxxflags".to_string(),
-        nodejs: None,
-    }
+    Config::default()
 }
 
 pub fn run_tests(config: &Config) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,8 @@ pub mod errors;
 
 pub use common::Config;
 
-#[deprecated(since="0.2.9", note="Use Config::default() instead")]
+#[deprecated(since="0.2.9",
+             note="Use Config::default() instead. This method will be removed in version 0.3.0")]
 pub fn default_config() -> Config {
     Config::default()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use common::{Config, Mode};
+use common::Mode;
 use common::{Pretty, DebugInfoGdb, DebugInfoLldb};
 use test::TestPaths;
 use std::borrow::ToOwned;
@@ -43,8 +43,9 @@ pub mod runtest;
 pub mod common;
 pub mod errors;
 
-pub use common::ConfigBuilder;
+pub use common::Config;
 
+#[deprecated(since="0.2.9", note="Use Config::default() instead")]
 pub fn default_config() -> Config {
     Config::default()
 }

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -1557,7 +1557,7 @@ actual:\n\
 
     /// Given a test path like `compile-fail/foo/bar.rs` Returns a name like
     ///
-    /// ```ignore
+    /// ```text
     ///     <output>/foo/bar-stage1
     /// ```
     fn output_base_name(&self) -> PathBuf {

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 fn run_mode(mode: &'static str) {
 
-    let mut config = compiletest::default_config();
+    let mut config = compiletest::ConfigBuilder::default().link_deps().finalize();
     let cfg_mode = mode.parse().ok().expect("Invalid mode");
 
     config.mode = cfg_mode;

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -4,11 +4,12 @@ use std::path::PathBuf;
 
 fn run_mode(mode: &'static str) {
 
-    let mut config = compiletest::ConfigBuilder::default().link_deps().finalize();
+    let mut config = compiletest::Config::default();
     let cfg_mode = mode.parse().ok().expect("Invalid mode");
 
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));
+    config.link_deps();
 
     compiletest::run_tests(&config);
 }


### PR DESCRIPTION
Apropos of our previous [conversation](https://github.com/laumann/compiletest-rs/issues/67), I thought it might make sense to make a builder pattern for the `Config` struct with the ability to include dependencies as compiler link flags. This is a big change and it might not desirable, so let me know what you think.