### PR TITLE
Add tempdir as an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ name = "compiletest_rs"
 [dependencies]
 log = "0.3.5"
 rustc-serialize = "0.3"
+tempdir = { version = "0.3", optional = true }
+
+[features]
+tmp = ["tempdir"]

--- a/src/common.rs
+++ b/src/common.rs
@@ -232,9 +232,25 @@ impl Config {
 #[cfg(feature = "tmp")]
 mod config_tempdir {
     use tempdir;
+    use std::ops;
+
     pub struct ConfigWithTemp {
         pub config: super::Config,
         pub tempdir: tempdir::TempDir,
+    }
+
+    impl ops::Deref for ConfigWithTemp {
+        type Target = super::Config;
+
+        fn deref(&self) -> &Self::Target {
+            &self.config
+        }
+    }
+
+    impl ops::DerefMut for ConfigWithTemp {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.config
+        }
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -224,8 +224,7 @@ impl Config {
 fn tempdir() -> PathBuf {
     tempdir::TempDir::new("compiletest")
         .expect("failed to create temporary directory")
-        .path()
-        .to_path_buf()
+        .into_path()
 }
 
 #[cfg(not(feature = "tmp"))]

--- a/src/common.rs
+++ b/src/common.rs
@@ -15,6 +15,9 @@ use std::str::FromStr;
 use std::path::PathBuf;
 use rustc;
 
+#[cfg(feature = "tmp")]
+use tempdir;
+
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Mode {
     CompileFail,
@@ -217,6 +220,19 @@ impl Config {
     }
 }
 
+#[cfg(feature = "tmp")]
+fn tempdir() -> PathBuf {
+    tempdir::TempDir::new("compiletest")
+        .expect("failed to create temporary directory")
+        .path()
+        .to_path_buf()
+}
+
+#[cfg(not(feature = "tmp"))]
+fn tempdir() -> PathBuf {
+    env::temp_dir()
+}
+
 impl Default for Config {
     fn default() -> Config {
         let platform = rustc::session::config::host_triple().to_string();
@@ -232,7 +248,7 @@ impl Default for Config {
             force_valgrind: false,
             llvm_filecheck: None,
             src_base: PathBuf::from("tests/run-pass"),
-            build_base: env::temp_dir(),
+            build_base: tempdir(),
             stage_id: "stage-id".to_owned(),
             mode: Mode::RunPass,
             run_ignored: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ extern crate test;
 extern crate rustc;
 extern crate rustc_serialize;
 
+#[cfg(feature = "tmp")] extern crate tempdir;
+
 #[macro_use]
 extern crate log;
 

--- a/test-project/Cargo.toml
+++ b/test-project/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Thomas Jespersen <laumann.thomas@gmail.com>"]
 
 [dev-dependencies.compiletest_rs]
 path = ".."
+features = ["tmp"]

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -10,8 +10,9 @@ fn run_mode(mode: &'static str) {
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));
     config.link_deps();
+    let wrapped_config = config.tempdir();
 
-    compiletest::run_tests(&config);
+    compiletest::run_tests(&wrapped_config.config);
 }
 
 #[test]

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -4,15 +4,14 @@ use std::path::PathBuf;
 
 fn run_mode(mode: &'static str) {
 
-    let mut config = compiletest::Config::default();
+    let mut config = compiletest::Config::default().tempdir();
     let cfg_mode = mode.parse().expect("Invalid mode");
 
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));
     config.link_deps();
-    let wrapped_config = config.tempdir();
 
-    compiletest::run_tests(&wrapped_config.config);
+    compiletest::run_tests(&config);
 }
 
 #[test]


### PR DESCRIPTION
Using feature "tmp" the build_base will be a temporary directory provided by the
tempdir crate. This provides a feature useful for running tests in parallel.

Fixes #72