### PR TITLE
Print the correct basename of the src dir

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ pub fn make_test_name(config: &Config, testpaths: &TestPaths) -> test::TestName 
     //
     //    run-pass/foo/bar/baz.rs
     let path =
-        PathBuf::from(config.mode.to_string())
+        PathBuf::from(config.src_base.file_name().unwrap())
         .join(&testpaths.relative_dir)
         .join(&testpaths.file.file_name().unwrap());
     test::DynTestName(format!("[{}] {}", config.mode, path.display()))

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -2174,8 +2174,6 @@ actual:\n\
     }
 
     fn run_ui_test(&self) {
-        println!("ui: {}", self.testpaths.file.display());
-
         let proc_res = self.compile_test();
 
         let expected_stderr_path = self.expected_output_path("stderr");


### PR DESCRIPTION
Thanks to @RalfJung for the fix

Fixes #76