### PR TITLE
fix #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ fn run_mode(mode: &'static str) {
     config.mode = mode.parse().expect("Invalid mode");
     config.src_base = PathBuf::from(format!("tests/{}", mode));
     config.link_deps(); // Populate config.target_rustcflags with dependencies on the path
+    config.clean_rmeta(); // If your tests import the parent crate, this helps with E0464
 
     compiletest::run_tests(&config);
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,6 +11,7 @@ pub use self::Mode::*;
 
 use std::env;
 use std::fmt;
+use std::fs::{read_dir, remove_file};
 use std::str::FromStr;
 use std::path::PathBuf;
 use rustc;
@@ -244,6 +245,30 @@ impl Config {
         }
 
         self.target_rustcflags = Some(flags);
+    }
+
+    /// Remove rmeta files from target `deps` directory
+    ///
+    /// These files are created by `cargo check`, and conflict with
+    /// `cargo build` rlib files, causing E0464 for tests which use
+    /// the parent crate.
+    pub fn clean_rmeta(&self) {
+        if self.target_rustcflags.is_some() {
+            for directory in self.target_rustcflags
+                .as_ref()
+                .unwrap()
+                .split_whitespace()
+                .filter(|s| s.ends_with("/deps"))
+            {
+                if let Ok(mut entries) = read_dir(directory) {
+                    while let Some(Ok(entry)) = entries.next() {
+                        if entry.file_name().to_string_lossy().ends_with(".rmeta") {
+                            let _ = remove_file(entry.path());
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[cfg(feature = "tmp")]

--- a/test-project/tests/compile-fail/with-own-crate.rs
+++ b/test-project/tests/compile-fail/with-own-crate.rs
@@ -1,6 +1,0 @@
-extern crate testp;
-//~^ ERROR E0464
-//~| ERROR E0463
-// ISSUE#78: This test requires `cargo check` before `cargo test` to
-// fail compilation
-fn main() {}

--- a/test-project/tests/compile-fail/with-own-crate.rs
+++ b/test-project/tests/compile-fail/with-own-crate.rs
@@ -1,0 +1,6 @@
+extern crate testp;
+//~^ ERROR E0464
+//~| ERROR E0463
+// ISSUE#78: This test requires `cargo check` before `cargo test` to
+// fail compilation
+fn main() {}

--- a/test-project/tests/run-pass/with-own-crate.rs
+++ b/test-project/tests/run-pass/with-own-crate.rs
@@ -1,0 +1,3 @@
+extern crate testp;
+
+fn main() {}

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -10,6 +10,7 @@ fn run_mode(mode: &'static str) {
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));
     config.link_deps();
+    config.clean_rmeta();
 
     compiletest::run_tests(&config);
 }


### PR DESCRIPTION
These paths come from the rustc build environment, so I suppose cleaning their `*.rmeta` files here is appropriate.

I'm ignoring errors here because:
- These are build artifacts
- E0464 would return later in the build