### PR TITLE
Add a note to the README concerning paths with spaces and link_deps()

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ let mut config = compiletest::Config::default();
 config.link_deps();
 ```
 
+Note that `link_deps()` should not be used if any of the added paths contain
+spaces, as these are currently not handled correctly.
+
 Example
 -------
 See the `test-project` folder for a complete working example using the


### PR DESCRIPTION
If any of the paths added to target_rustcflags by link_deps() contain
spaces, then compiletest breaks as `split_maybe_args` does not handle
paths with spaces correctly.