### PR TITLE
Fix build on latest nightly

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -622,7 +622,7 @@ fn expand_variables(mut value: String, config: &Config) -> String {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// let mut s = "normalize-stderr-32bit: \"something (32 bits)\" -> \"something ($WORD bits)\".";
 /// let first = parse_normalization_string(&mut s);
 /// assert_eq!(first, Some("something (32 bits)".to_owned()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ pub fn make_test_name(config: &Config, testpaths: &TestPaths) -> test::TestName 
 pub fn make_test_closure(config: &Config, testpaths: &TestPaths) -> test::TestFn {
     let config = config.clone();
     let testpaths = testpaths.clone();
-    test::DynTestFn(Box::new(move |()| {
+    test::DynTestFn(Box::new(move || {
         runtest::run(config, &testpaths)
     }))
 }

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -1603,8 +1603,7 @@ actual:\n\
     }
 
     /// Given a test path like `compile-fail/foo/bar.rs` Returns a name like
-    ///
-    ///     <output>/foo/bar-stage1
+    /// `<output>/foo/bar-stage1`
     fn output_base_name(&self) -> PathBuf {
         let dir = self.config.build_base.join(&self.testpaths.relative_dir);
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/46636 changed `DynTestFn`, and something else seems to have made `cargo test` more eager to try to test code in doc comments.