### PR TITLE
update for TestPaths being moved

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -226,6 +226,13 @@ pub struct Config {
     pub nodejs: Option<String>,
 }
 
+#[derive(Clone)]
+pub struct TestPaths {
+    pub file: PathBuf,         // e.g., compile-test/foo/bar/baz.rs
+    pub base: PathBuf,         // e.g., compile-test, auxiliary
+    pub relative_dir: PathBuf, // e.g., foo/bar
+}
+
 impl Config {
     /// Add rustc flags to link with the crate's dependencies in addition to the crate itself
     pub fn link_deps(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,8 @@ use std::ffi::OsString;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use common::Mode;
+use common::{Mode, TestPaths};
 use common::{Pretty, DebugInfoGdb, DebugInfoLldb};
-use test::TestPaths;
 
 use self::header::EarlyProps;
 

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use common::Config;
+use common::{Config, TestPaths};
 use common::{CompileFail, ParseFail, Pretty, RunFail, RunPass, RunPassValgrind};
 use common::{Codegen, DebugInfoLldb, DebugInfoGdb, Rustdoc, CodegenUnits};
 use common::{Incremental, RunMake, Ui, MirOpt};
@@ -17,7 +17,6 @@ use errors::{self, ErrorKind, Error};
 use filetime::FileTime;
 use json;
 use header::TestProps;
-use test::TestPaths;
 use util::logv;
 
 use std::collections::HashMap;


### PR DESCRIPTION
Fixes breakage from https://github.com/rust-lang/rust/pull/47106.