### PR TITLE
Remove rustc dependecy, get TARGET and HOST from build script instead

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+use std::env;
+
+pub fn main() {
+    println!("cargo:rustc-env=TARGET={}", env::var("TARGET").unwrap());
+    println!("cargo:rustc-env=HOST={}", env::var("HOST").unwrap());
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -14,7 +14,6 @@ use std::fmt;
 use std::fs::{read_dir, remove_file};
 use std::str::FromStr;
 use std::path::PathBuf;
-use rustc;
 
 use test::ColorConfig;
 use runtest::dylib_env_var;
@@ -319,8 +318,6 @@ mod config_tempdir {
 
 impl Default for Config {
     fn default() -> Config {
-        let platform = rustc::session::config::host_triple().to_string();
-
         Config {
             compile_lib_path: PathBuf::from(""),
             run_lib_path: PathBuf::from(""),
@@ -342,8 +339,8 @@ impl Default for Config {
             runtool: None,
             host_rustcflags: None,
             target_rustcflags: None,
-            target: platform.clone(),
-            host: platform.clone(),
+            target: env!("TARGET").to_string(),
+            host: env!("HOST").to_string(),
             gdb: None,
             gdb_version: None,
             gdb_native_rust: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 
 #![crate_type = "lib"]
 
-#![feature(rustc_private)]
 #![feature(test)]
 #![feature(slice_rotate)]
 
@@ -19,7 +18,6 @@
 #[cfg(unix)]
 extern crate libc;
 extern crate test;
-extern crate rustc;
 extern crate rustc_serialize;
 
 #[cfg(feature = "tmp")] extern crate tempdir;


### PR DESCRIPTION
Fixes https://github.com/laumann/compiletest-rs/issues/91