### PR TITLE
TestOpts::quiet -> TestOpts.format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         filter: config.filter.clone(),
         filter_exact: config.filter_exact,
         run_ignored: config.run_ignored,
-        quiet: config.quiet,
+        format: if config.quiet { test::OutputFormat::Terse } else { test::OutputFormat::Pretty },
         logfile: config.logfile.clone(),
         run_tests: true,
         bench_benchmarks: true,


### PR DESCRIPTION
Fixes breakage from https://github.com/rust-lang/rust/pull/46450.

Mimics the change to `src/tools/compiletest/src/main.rs` in https://github.com/rust-lang/rust/commit/588a6a35be4446fbaaa792d08efee51e04e61fe8.