### PR TITLE
Call `rotate_left` instead of `rotate`.

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -2611,7 +2611,7 @@ fn read2_abbreviated(mut child: Child) -> io::Result<Output> {
                     *skipped += data.len();
                     if data.len() <= TAIL_LEN {
                         tail[..data.len()].copy_from_slice(data);
-                        tail.rotate(data.len());
+                        tail.rotate_left(data.len());
                     } else {
                         tail.copy_from_slice(&data[(data.len() - TAIL_LEN)..]);
                     }


### PR DESCRIPTION
The `rotate` method has been deprecated in favor of `rotate_left` and `rotate_right` since rust-lang/rust#46777 (2018 Jan 10th), and will be deleted in rust-lang/rust#48450.