### PR TITLE
Update dependencies: Use serde_json instead of rustc-serialize, update winapi, log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "compiletest_rs"
 diff = "0.1.10"
 filetime = "0.1"
 getopts = "0.2"
-log = "0.3"
+log = "0.4"
 tempdir = { version = "0.3", optional = true }
 serde = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ serde_derive = "1.0"
 libc = "0.2"
 
 [target."cfg(windows)".dependencies]
-miow = "0.2"
-winapi = "0.2"
+miow = "0.3"
+winapi = { version = "0.3", features = ["winerror"] }
 
 [features]
 tmp = ["tempdir"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ diff = "0.1.10"
 filetime = "0.1"
 getopts = "0.2"
 log = "0.3"
-rustc-serialize = "0.3"
 tempdir = { version = "0.3", optional = true }
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"

--- a/src/json.rs
+++ b/src/json.rs
@@ -17,7 +17,7 @@ use runtest::ProcRes;
 // These structs are a subset of the ones found in
 // `syntax::json`.
 
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize)]
 struct Diagnostic {
     message: String,
     code: Option<DiagnosticCode>,
@@ -27,7 +27,7 @@ struct Diagnostic {
     rendered: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Deserialize, Clone)]
 struct DiagnosticSpan {
     file_name: String,
     line_start: usize,
@@ -40,7 +40,7 @@ struct DiagnosticSpan {
     expansion: Option<Box<DiagnosticSpanMacroExpansion>>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Deserialize, Clone)]
 struct DiagnosticSpanMacroExpansion {
     /// span where macro was applied to generate this code
     span: DiagnosticSpan,
@@ -49,7 +49,7 @@ struct DiagnosticSpanMacroExpansion {
     macro_decl_name: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Deserialize, Clone)]
 struct DiagnosticCode {
     /// The code itself.
     code: String,

--- a/src/json.rs
+++ b/src/json.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use errors::{Error, ErrorKind};
-use rustc_serialize::json;
+use serde_json;
 use std::str::FromStr;
 use std::path::Path;
 use runtest::ProcRes;
@@ -17,7 +17,7 @@ use runtest::ProcRes;
 // These structs are a subset of the ones found in
 // `syntax::json`.
 
-#[derive(RustcEncodable, RustcDecodable)]
+#[derive(Serialize, Deserialize)]
 struct Diagnostic {
     message: String,
     code: Option<DiagnosticCode>,
@@ -27,7 +27,7 @@ struct Diagnostic {
     rendered: Option<String>,
 }
 
-#[derive(RustcEncodable, RustcDecodable, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 struct DiagnosticSpan {
     file_name: String,
     line_start: usize,
@@ -40,7 +40,7 @@ struct DiagnosticSpan {
     expansion: Option<Box<DiagnosticSpanMacroExpansion>>,
 }
 
-#[derive(RustcEncodable, RustcDecodable, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 struct DiagnosticSpanMacroExpansion {
     /// span where macro was applied to generate this code
     span: DiagnosticSpan,
@@ -49,7 +49,7 @@ struct DiagnosticSpanMacroExpansion {
     macro_decl_name: String,
 }
 
-#[derive(RustcEncodable, RustcDecodable, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 struct DiagnosticCode {
     /// The code itself.
     code: String,
@@ -67,7 +67,7 @@ fn parse_line(file_name: &str, line: &str, output: &str, proc_res: &ProcRes) -> 
     // The compiler sometimes intermingles non-JSON stuff into the
     // output.  This hack just skips over such lines. Yuck.
     if line.starts_with('{') {
-        match json::decode::<Diagnostic>(line) {
+        match serde_json::from_str::<Diagnostic>(line) {
             Ok(diagnostic) => {
                 let mut expected_errors = vec![];
                 push_expected_errors(&mut expected_errors, &diagnostic, &[], file_name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 extern crate libc;
 extern crate test;
 extern crate rustc;
-extern crate rustc_serialize;
 
 #[cfg(feature = "tmp")] extern crate tempdir;
 
@@ -28,6 +27,9 @@ extern crate rustc_serialize;
 extern crate log;
 extern crate filetime;
 extern crate diff;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 
 use std::env;
 use std::ffi::OsString;

--- a/src/read2.rs
+++ b/src/read2.rs
@@ -115,7 +115,7 @@ mod imp {
     use self::miow::iocp::{CompletionPort, CompletionStatus};
     use self::miow::pipe::NamedPipe;
     use self::miow::Overlapped;
-    use self::winapi::ERROR_BROKEN_PIPE;
+    use self::winapi::shared::winerror::ERROR_BROKEN_PIPE;
 
     struct Pipe<'a> {
         dst: &'a mut Vec<u8>,


### PR DESCRIPTION
[`rustc-serialize`](https://github.com/rust-lang-deprecated/rustc-serialize#rustc-serialize) is deprecated.