### PR TITLE
Fix "pretty" mode tests

### DIFF
--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -344,8 +344,7 @@ impl<'test> TestCx<'test> {
 
         let mut rustc = Command::new(&self.config.rustc_path);
         rustc.arg("-")
-            .arg("-Zunstable-options")
-            .args(&["--unpretty", &pretty_type])
+            .args(&["-Z", &format!("unpretty={}", pretty_type)])
             .args(&["--target", &self.config.target])
             .arg("-L").arg(&aux_dir)
             .args(self.split_maybe_args(&self.config.target_rustcflags))

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -263,6 +263,12 @@ impl<'test> TestCx<'test> {
         }
     }
 
+    #[cfg(feature = "stable")]
+    fn run_pretty_test(&self) {
+        self.fatal("pretty-printing tests can only be used with nightly Rust".into());
+    }
+
+    #[cfg(not(feature = "stable"))]
     fn run_pretty_test(&self) {
         if self.props.pp_exact.is_some() {
             logv(self.config, "testing for exact pretty-printing".to_owned());

--- a/test-project/tests/pretty/macro.pp
+++ b/test-project/tests/pretty/macro.pp
@@ -1,0 +1,13 @@
+#![feature(prelude_import)]
+#![no_std]
+#[prelude_import]
+use std::prelude::v1::*;
+#[macro_use]
+extern crate std;
+// pretty-compare-only
+// pretty-mode:expanded
+// pp-exact:macro.pp
+
+macro_rules! square(( $ x : expr ) => { $ x * $ x } ;);
+
+fn f() -> i8 { 5 * 5 }

--- a/test-project/tests/pretty/macro.rs
+++ b/test-project/tests/pretty/macro.rs
@@ -1,0 +1,13 @@
+// pretty-compare-only
+// pretty-mode:expanded
+// pp-exact:macro.pp
+
+macro_rules! square {
+    ($x:expr) => {
+        $x * $x
+    };
+}
+
+fn f() -> i8 {
+    square!(5)
+}

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -19,4 +19,5 @@ fn run_mode(mode: &'static str) {
 fn compile_test() {
     run_mode("compile-fail");
     run_mode("run-pass");
+    run_mode("pretty");
 }

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -19,5 +19,7 @@ fn run_mode(mode: &'static str) {
 fn compile_test() {
     run_mode("compile-fail");
     run_mode("run-pass");
+
+    #[cfg(not(feature = "stable"))]
     run_mode("pretty");
 }


### PR DESCRIPTION
Adjust to [Rust command line changes](https://github.com/rust-lang/rust/pull/47440) related to "pretty" mode tests.

Fixes #111