### PR TITLE
Consider callsite of macro expansions

### DIFF
--- a/test-project/tests/compile-fail/macro.rs
+++ b/test-project/tests/compile-fail/macro.rs
@@ -1,0 +1,9 @@
+macro_rules! macro_with_error {
+    ( ) => {
+        let x: u64 = true;
+    };
+}
+
+fn main() {
+    macro_with_error!();  //~ ERROR mismatched types
+}


### PR DESCRIPTION
This fixes #48

In case of macros, the correct span to look at is the one that corresponds to the call site.