### PR TITLE
Fix error message in test, run tests on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,6 @@ environment:
       CHANNEL: nightly
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: nightly
-    - TARGET: x86_64-pc-windows-gnu
-      CHANNEL: stable
-    - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: stable
 
 install:
   - curl -sSf -o rustup-init.exe https://win.rustup.rs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,8 @@ build: false
 
 test_script:
   - if %CHANNEL%==stable (cargo build --features stable) else (cargo build)
+  - cd test-project && if %CHANNEL%==stable (cargo test --features stable) else (cargo test)
 
 branches:
   only:
     - master
-

--- a/test-project/tests/compile-fail/trait-bounds-cant-coerce.rs
+++ b/test-project/tests/compile-fail/trait-bounds-cant-coerce.rs
@@ -23,8 +23,8 @@ fn c(x: Box<Foo+Sync+Send>) {
 fn d(x: Box<Foo>) {
     a(x); //~  ERROR mismatched types
           //~| expected trait `Foo + std::marker::Send`, found trait `Foo`
-          //~| expected type `std::boxed::Box<Foo + std::marker::Send + 'static>`
-          //~| found type `std::boxed::Box<Foo + 'static>`
+          //~| expected type `std::boxed::Box<(dyn Foo + std::marker::Send + 'static)>`
+          //~| found type `std::boxed::Box<(dyn Foo + 'static)>`
 }
 
 fn main() { }

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -9,7 +9,7 @@ fn run_mode(mode: &'static str) {
 
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));
-    config.link_deps();
+    config.target_rustcflags = Some("-L target/debug -L target/debug/deps".to_string());
     config.clean_rmeta();
 
     compiletest::run_tests(&config);


### PR DESCRIPTION
This fixes tests on Travis and enable tests on AppVeyor.

However, tests on AppVeyor are failing: https://ci.appveyor.com/project/fpoli/compiletest-rs/build/1.0.1
It's probably some Window-related issue (path separators...). I suggest to open a new issue, as I can't debug this easily.

Closes #113 