### PR TITLE
Add regex support to replacements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ diff = "0.1.10"
 filetime = "0.2"
 getopts = "0.2"
 log = "0.4"
+regex = "1.0"
 tempfile = { version = "3.0", optional = true }
 serde = "1.0"
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ extern crate test;
 
 #[macro_use]
 extern crate log;
+extern crate regex;
 extern crate filetime;
 extern crate diff;
 extern crate serde_json;

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -16,6 +16,7 @@ use diff;
 use errors::{self, ErrorKind, Error};
 use filetime::FileTime;
 use json;
+use regex::Regex;
 use header::TestProps;
 use util::logv;
 
@@ -2454,7 +2455,8 @@ actual:\n\
               .replace("\r\n", "\n") // normalize for linebreaks on windows
               .replace("\t", "\\t"); // makes tabs visible
         for rule in custom_rules {
-            normalized = normalized.replace(&rule.0, &rule.1);
+            let re = Regex::new(&rule.0).expect("bad regex in custom normalization rule");
+            normalized = re.replace_all(&normalized, &rule.1[..]).into_owned();
         }
         normalized
     }


### PR DESCRIPTION
This makes replacements work as they do upstream; the code was pulled directly from upstream, excepting the `regex` version which is `1.0` here as opposed to `0.2` upstream.