### PR TITLE
Fix macro.pp for latest nightly

### DIFF
--- a/test-project/tests/pretty/macro.pp
+++ b/test-project/tests/pretty/macro.pp
@@ -1,7 +1,7 @@
 #![feature(prelude_import)]
 #![no_std]
 #[prelude_import]
-use std::prelude::v1::*;
+use ::std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 // pretty-compare-only


### PR DESCRIPTION
The pretty-print output decided to add "::" in places (apparently).