### PR TITLE
Fix nightly run ignored

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 #[cfg(not(feature = "norustc"))]
 use rustc;
 
-use test::{ColorConfig, RunIgnored};
+use test::ColorConfig;
 use runtest::dylib_env_var;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -143,7 +143,7 @@ pub struct Config {
     pub mode: Mode,
 
     /// Run ignored tests
-    pub run_ignored: RunIgnored,
+    pub run_ignored: bool,
 
     /// Only run tests that match this filter
     pub filter: Option<String>,
@@ -337,7 +337,7 @@ impl Default for Config {
             build_base: env::temp_dir(),
             stage_id: "stage-id".to_owned(),
             mode: Mode::RunPass,
-            run_ignored: RunIgnored::No,
+            run_ignored: false,
             filter: None,
             filter_exact: false,
             logfile: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
     test::TestOpts {
         filter: config.filter.clone(),
         filter_exact: config.filter_exact,
-        run_ignored: config.run_ignored,
+        run_ignored: if config.run_ignored { test::RunIgnored::Yes } else { test::RunIgnored::No },
         format: if config.quiet { test::OutputFormat::Terse } else { test::OutputFormat::Pretty },
         logfile: config.logfile.clone(),
         run_tests: true,


### PR DESCRIPTION
@SergioBenitez @phansch What do you think? I think this makes a little more sense (as `RunIgnored` was added to `libtest`)