### PR TITLE
No longer need slice_rotate feature gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 
 #![cfg_attr(not(feature = "norustc"), feature(rustc_private))]
 #![cfg_attr(not(feature = "stable"), feature(test))]
-#![cfg_attr(not(feature = "stable"), feature(slice_rotate))]
 
 #![deny(unused_imports)]
 


### PR DESCRIPTION
This feature has been stable for a long time.

```console
warning: the feature `slice_rotate` has been stable since 1.26.0 and no longer requires an attribute to enable
  --> src/lib.rs:15:46
   |
15 | #![cfg_attr(not(feature = "stable"), feature(slice_rotate))]
   |                                              ^^^^^^^^^^^^
   |
   = note: #[warn(stable_features)] on by default
```