### PR TITLE
expose ConfigWithTemp type

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -280,7 +280,7 @@ impl Config {
     }
 
     #[cfg(feature = "tmp")]
-    pub fn tempdir(mut self) -> config_tempdir::ConfigWithTemp {
+    pub fn tempdir(mut self) -> ConfigWithTemp {
         use tempfile;
         let tmp = tempfile::Builder::new().prefix("compiletest").tempdir()
             .expect("failed to create temporary directory");
@@ -316,6 +316,9 @@ mod config_tempdir {
         }
     }
 }
+
+#[cfg(feature = "tmp")]
+pub use self::config_tempdir::ConfigWithTemp;
 
 
 impl Default for Config {


### PR DESCRIPTION
It is the return type of a public function, and as such should be public as well.

Right now, it is impossible to write a helper function in my own crate that prepares a configuration, because it wants to return a `ConfigWithTemp` and I cannot write down that type.