### PR TITLE
Add rustfix support from rustc (rough rustc copy)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tempfile = { version = "3.0", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+rustfix = "0.4.1"
 tester = { version = "0.5", optional = true }
 
 [target."cfg(unix)".dependencies]

--- a/src/common.rs
+++ b/src/common.rs
@@ -234,6 +234,10 @@ pub struct TestPaths {
     pub relative_dir: PathBuf, // e.g., foo/bar
 }
 
+pub const UI_STDERR: &str = "stderr";
+pub const UI_STDOUT: &str = "stdout";
+pub const UI_FIXED: &str = "fixed";
+
 impl Config {
     /// Add rustc flags to link with the crate's dependencies in addition to the crate itself
     pub fn link_deps(&mut self) {

--- a/src/header.rs
+++ b/src/header.rs
@@ -222,6 +222,8 @@ pub struct TestProps {
     // customized normalization rules
     pub normalize_stdout: Vec<(String, String)>,
     pub normalize_stderr: Vec<(String, String)>,
+    pub run_rustfix: bool,
+    pub rustfix_only_machine_applicable: bool,
 }
 
 impl TestProps {
@@ -250,6 +252,8 @@ impl TestProps {
             run_pass: false,
             normalize_stdout: vec![],
             normalize_stderr: vec![],
+            run_rustfix: false,
+            rustfix_only_machine_applicable: false,
         }
     }
 
@@ -370,6 +374,15 @@ impl TestProps {
             }
             if let Some(rule) = config.parse_custom_normalization(ln, "normalize-stderr") {
                 self.normalize_stderr.push(rule);
+            }
+
+            if !self.run_rustfix {
+                self.run_rustfix = config.parse_run_rustfix(ln);
+            }
+
+            if !self.rustfix_only_machine_applicable {
+                self.rustfix_only_machine_applicable =
+                    config.parse_rustfix_only_machine_applicable(ln);
             }
         });
 
@@ -587,6 +600,14 @@ impl Config {
         }
 
         None
+    }
+
+    fn parse_run_rustfix(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "run-rustfix")
+    }
+
+    fn parse_rustfix_only_machine_applicable(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "rustfix-only-machine-applicable")
     }
 }
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -24,6 +24,7 @@ struct Diagnostic {
     level: String,
     spans: Vec<DiagnosticSpan>,
     children: Vec<Diagnostic>,
+    rendered: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -69,6 +70,28 @@ struct DiagnosticCode {
     code: String,
     /// An explanation for the code.
     explanation: Option<String>,
+}
+
+pub fn extract_rendered(output: &str, proc_res: &ProcRes) -> String {
+    output
+        .lines()
+        .filter_map(|line| {
+            if line.starts_with('{') {
+                match serde_json::from_str::<Diagnostic>(line) {
+                    Ok(diagnostic) => diagnostic.rendered,
+                    Err(error) => {
+                        proc_res.fatal(Some(&format!(
+                            "failed to decode compiler output as json: \
+                             `{}`\nline: {}\noutput: {}",
+                            error, line, output
+                        )));
+                    }
+                }
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 pub fn parse_output(file_name: &str, output: &str, proc_res: &ProcRes) -> Vec<Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ extern crate diff;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
+extern crate rustfix;
 
 use std::env;
 use std::ffi::OsString;

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -19,6 +19,7 @@ fn run_mode(mode: &'static str) {
 fn compile_test() {
     run_mode("compile-fail");
     run_mode("run-pass");
+    run_mode("ui");
 
     #[cfg(not(feature = "stable"))]
     run_mode("pretty");

--- a/test-project/tests/ui/dyn-keyword.fixed
+++ b/test-project/tests/ui/dyn-keyword.fixed
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-rustfix
+
+#![allow(unused_variables)]
+#![deny(keyword_idents)]
+
+fn main() {
+    let r#dyn = (); //~ ERROR dyn
+    //~^ WARN hard error in the 2018 edition
+}

--- a/test-project/tests/ui/dyn-keyword.rs
+++ b/test-project/tests/ui/dyn-keyword.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// run-rustfix
+
+#![allow(unused_variables)]
+#![deny(keyword_idents)]
+
+fn main() {
+    let dyn = (); //~ ERROR dyn
+    //~^ WARN hard error in the 2018 edition
+}

--- a/test-project/tests/ui/dyn-keyword.stderr
+++ b/test-project/tests/ui/dyn-keyword.stderr
@@ -1,0 +1,16 @@
+error: `dyn` is a keyword in the 2018 edition
+  --> $DIR/dyn-keyword.rs:17:9
+   |
+17 |     let dyn = (); //~ ERROR dyn
+   |         ^^^ help: you can use a raw identifier to stay compatible: `r#dyn`
+   |
+note: lint level defined here
+  --> $DIR/dyn-keyword.rs:14:9
+   |
+14 | #![deny(keyword_idents)]
+   |         ^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This adds rustfix integration that was already present in the compiletest of
rustc. We would like to use this in Clippy to be able to test that all
suggestions can be applied by rustfix and that the changes are compiling as
well. This would probably also benefit other tools that make use of lints.

Associated Clippy PR that uses this branch: https://github.com/rust-lang/rust-clippy/pull/3519

Some open questions:

1. Should rustfix support be hidden behind a cargo feature? I can imagine that only a small portion of compiletest-rs users would need rustfix as a dependency.
2. I'm not really sure how this could be tested properly?