### PR TITLE
Add unstable cargo feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 matrix:
  include:
    - rust: nightly
-     env: FEATURES=""
+     env: FEATURES="--features unstable"
    - rust: beta
      env: FEATURES="--features stable"
    - rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletest_rs"
-version = "0.3.20"
+version = "0.3.21"
 authors = [ "The Rust Project Developers"
           , "Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>"
           , "Manish Goregaokar <manishsmail@gmail.com>"
@@ -26,7 +26,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 rustfix = "0.4.1"
 tester = { version = "0.5", optional = true }
-libtest = "0.0.1"
+libtest = { version =  "0.0.1", optional = true }
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"
@@ -39,3 +39,4 @@ winapi = { version = "0.3", features = ["winerror"] }
 tmp = ["tempfile"]
 norustc = []
 stable = ["norustc", "tester"]
+unstable = [ "libtest" ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
 build: false
 
 test_script:
-  - if %CHANNEL%==stable (cargo build --features stable) else (cargo build)
+  - if %CHANNEL%==stable (cargo build --features stable) else (cargo build --features unstable)
   - cd test-project && if %CHANNEL%==stable (cargo test --features stable) else (cargo test)
 
 branches:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,10 @@ extern crate rustc;
 
 #[cfg(unix)]
 extern crate libc;
+#[cfg(not(feature = "stable"))]
 extern crate libtest as test;
+#[cfg(feature = "stable")]
+extern crate test;
 
 #[cfg(feature = "tmp")] extern crate tempfile;
 


### PR DESCRIPTION
cc @Manishearth 

This adds an `unstable` cargo feature, that those wanting to use `compiletest` with the nightly channel should enable.