### PR TITLE
Add a proc-macro UI test example to the test project

### DIFF
--- a/test-project/tests/nightly/auxiliary/simple_proc_macro.rs
+++ b/test-project/tests/nightly/auxiliary/simple_proc_macro.rs
@@ -1,0 +1,12 @@
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::{TokenStream};
+
+#[proc_macro]
+pub fn macro_test(input_stream: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/test-project/tests/nightly/some-proc-macro.rs
+++ b/test-project/tests/nightly/some-proc-macro.rs
@@ -1,0 +1,13 @@
+// run-pass
+// aux-build:simple_proc_macro.rs
+
+#![feature(proc_macro_hygiene)]
+
+extern crate simple_proc_macro;
+use simple_proc_macro::macro_test;
+
+fn main() {
+    println!("hi");
+    macro_test!(2);
+}
+

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -2,13 +2,14 @@ extern crate compiletest_rs as compiletest;
 
 use std::path::PathBuf;
 
-fn run_mode(mode: &'static str) {
-
+fn run_mode(mode: &'static str, custom_dir: Option<&'static str>) {
     let mut config = compiletest::Config::default().tempdir();
     let cfg_mode = mode.parse().expect("Invalid mode");
 
     config.mode = cfg_mode;
-    config.src_base = PathBuf::from(format!("tests/{}", mode));
+
+    let dir = custom_dir.unwrap_or(mode);
+    config.src_base = PathBuf::from(format!("tests/{}", dir));
     config.target_rustcflags = Some("-L target/debug -L target/debug/deps".to_string());
     config.clean_rmeta();
 
@@ -17,10 +18,12 @@ fn run_mode(mode: &'static str) {
 
 #[test]
 fn compile_test() {
-    run_mode("compile-fail");
-    run_mode("run-pass");
-    run_mode("ui");
+    run_mode("compile-fail", None);
+    run_mode("run-pass", None);
+    run_mode("ui", None);
 
     #[cfg(not(feature = "stable"))]
-    run_mode("pretty");
+    run_mode("pretty", None);
+    #[cfg(not(feature = "stable"))]
+    run_mode("ui", Some("nightly"));
 }


### PR DESCRIPTION
Taken from work on https://github.com/rust-lang/rust-clippy/issues/3741.

I think this is a useful test to have because it tests

* the `run-pass` header
* the `aux-build` header, building auxiliary files
* the `no-prefer-dynamic` header
* proc-macro crate interactions with all of the above
* running of UI tests that include auxiliary files

There's no tests for any of the above right now.