### PR TITLE
preserve non-JSON lines during normalization

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -88,7 +88,8 @@ pub fn extract_rendered(output: &str, proc_res: &ProcRes) -> String {
                     }
                 }
             } else {
-                None
+                // preserve non-JSON lines, such as ICEs
+                Some(format!("{}\n", line))
             }
         })
         .collect()


### PR DESCRIPTION
Fixes https://github.com/laumann/compiletest-rs/issues/169

I am not sure what the usual process is, do you want the files here to be verbatim identical to what is in rustc? The diff seems quite large currently, at least for `runtest.rs`. I will submit the same thing there as well, if it still applies.