### PR TITLE
Revert "Move to libtest"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletest_rs"
-version = "0.0.6"
+version = "0.0.7"
 authors = [ "The Rust Project Developers"
           , "Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>"
           , "Manish Goregaokar <manishsmail@gmail.com>"


### PR DESCRIPTION
We reverted the libtest changes in rustc (https://github.com/rust-lang/rust/pull/59766#issuecomment-480615192), this reverts the change made here to use libtest, allowing us to finally build on stable and nightly again.