### PR TITLE
Revert "move to libtest"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletest_rs"
-version = "0.3.20"
+version = "0.3.19"
 authors = [ "The Rust Project Developers"
           , "Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>"
           , "Manish Goregaokar <manishsmail@gmail.com>"
@@ -26,7 +26,6 @@ serde_json = "1.0"
 serde_derive = "1.0"
 rustfix = "0.4.1"
 tester = { version = "0.5", optional = true }
-libtest = "0.0.1"
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletest_rs"
-version = "0.3.19"
+version = "0.3.21"
 authors = [ "The Rust Project Developers"
           , "Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>"
           , "Manish Goregaokar <manishsmail@gmail.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ extern crate rustc;
 
 #[cfg(unix)]
 extern crate libc;
-extern crate libtest as test;
+extern crate test;
 
 #[cfg(feature = "tmp")] extern crate tempfile;
 


### PR DESCRIPTION
We reverted the libtest changes in rustc (https://github.com/rust-lang/rust/pull/59766#issuecomment-480615192), this reverts the change made here to use libtest, allowing us to finally build on stable and nightly again.