### PR TITLE
Fix breakage with stable feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         skip: vec![],
         list: false,
         options: test::Options::new(),
+        #[cfg(not(feature = "stable"))]
         report_time: false,
     }
 }


### PR DESCRIPTION
Fix breakage with stable feature reported in https://github.com/laumann/compiletest-rs/issues/186#issuecomment-535548776. (At the same time, [CI failures](https://travis-ci.org/laumann/compiletest-rs/builds/591073520?utm_source=github_status&utm_medium=notification) are also fixed)