### PR TITLE
Replace deprecated try! macro with ? operator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,8 +151,8 @@ fn collect_tests_from_dir(config: &Config,
                           -> io::Result<()> {
     // Ignore directories that contain a file
     // `compiletest-ignore-dir`.
-    for file in try!(fs::read_dir(dir)) {
-        let file = try!(file);
+    for file in fs::read_dir(dir)? {
+        let file = file?;
         let name = file.file_name();
         if name == *"compiletest-ignore-dir" {
             return Ok(());
@@ -179,9 +179,9 @@ fn collect_tests_from_dir(config: &Config,
 
     // Add each `.rs` file as a test, and recurse further on any
     // subdirectories we find, except for `aux` directories.
-    let dirs = try!(fs::read_dir(dir));
+    let dirs = fs::read_dir(dir)?;
     for file in dirs {
-        let file = try!(file);
+        let file = file?;
         let file_path = file.path();
         let file_name = file.file_name();
         if is_test(&file_name) {
@@ -212,11 +212,11 @@ fn collect_tests_from_dir(config: &Config,
                 fs::create_dir_all(&build_dir).unwrap();
             } else {
                 debug!("found directory: {:?}", file_path.display());
-                try!(collect_tests_from_dir(config,
+                collect_tests_from_dir(config,
                                        base,
                                        &file_path,
                                        &relative_file_path,
-                                       tests));
+                                       tests)?;
             }
         } else {
             debug!("found other file/directory: {:?}", file_path.display());


### PR DESCRIPTION
[try! macro has been deprecated in Rust 1.39.](https://github.com/rust-lang/rust/blob/d046ffddc4bd50e04ffc3ff9f766e2ac71f74d50/src/libcore/macros.rs#L305)