### PR TITLE
Rustup to https://github.com/rust-lang/rust/pull/64873

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         skip: vec![],
         list: false,
         options: test::Options::new(),
-        report_time: false,
+        time_options: None,
     }
 }
 


### PR DESCRIPTION
`report_time` was renamed to `time_options` and is now an `Option`.

First step of fixing Clippy and Miri toolstate after https://github.com/rust-lang/rust/pull/64873