### PR TITLE
Add test type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,8 @@ pub fn make_test(config: &Config, testpaths: &TestPaths) -> test::TestDescAndFn 
             ignore: early_props.ignore,
             should_panic: should_panic,
             allow_fail: false,
+            #[cfg(not(feature = "stable"))]
+            test_type: test::TestType::Unknown,
         },
         testfn: make_test_closure(config, testpaths),
     }


### PR DESCRIPTION
This field was recently added to nightly. We'll use Unknown, because the tests
written through compiletest doesn't really fit in any of the other categories.