### PR TITLE
Add dyn keywords

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -400,7 +400,7 @@ impl TestProps {
     }
 }
 
-fn iter_header(testfile: &Path, cfg: Option<&str>, it: &mut FnMut(&str)) {
+fn iter_header(testfile: &Path, cfg: Option<&str>, it: &mut dyn FnMut(&str)) {
     if testfile.is_dir() {
         return;
     }

--- a/src/read2.rs
+++ b/src/read2.rs
@@ -42,7 +42,7 @@ mod imp {
 
     pub fn read2(mut out_pipe: ChildStdout,
                  mut err_pipe: ChildStderr,
-                 data: &mut FnMut(bool, &mut Vec<u8>, bool)) -> io::Result<()> {
+                 data: &mut dyn FnMut(bool, &mut Vec<u8>, bool)) -> io::Result<()> {
         unsafe {
             libc::fcntl(out_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
             libc::fcntl(err_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);


### PR DESCRIPTION
Trait objects without explicit `dyn` are deprecated and gives a warning when
compiling.