### PR TITLE
Add rustc-dev component in nightly test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ matrix:
  include:
    - rust: nightly
      env: FEATURES=""
+     before_script:
+       rustup component add rustc-dev
    - rust: beta
      env: FEATURES="--features stable"
    - rust: stable


### PR DESCRIPTION
rustc has been removed from the nightly rust distribution. In order to use it (for `extern crate rustc`), we need to add the `rustc-dev` component first. 