### PR TITLE
Don't use `tester` on `rustc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 rustfix = "0.4.1"
-tester = { version = "0.5" }
+tester = { version = "0.5", package = "tester" }
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,21 @@
 #![crate_type = "lib"]
 
 #![cfg_attr(feature = "rustc", feature(rustc_private))]
+#![cfg_attr(feature = "rustc", feature(test))]
 
 #![deny(unused_imports)]
 
 #[cfg(feature = "rustc")]
 extern crate rustc;
 
+#[cfg(feature = "rustc")]
+extern crate test;
+
+#[cfg(not(feature = "rustc"))]
+extern crate tester as test;
+
 #[cfg(unix)]
 extern crate libc;
-extern crate test;
 
 #[cfg(feature = "tmp")] extern crate tempfile;
 
@@ -109,6 +115,10 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
     test::TestOpts {
         filter: config.filter.clone(),
         filter_exact: config.filter_exact,
+        #[cfg(feature = "rustc")]
+        force_run_in_process: false,
+        #[cfg(feature = "rustc")]
+        exclude_should_panic: false,
         run_ignored: if config.run_ignored { test::RunIgnored::Yes } else { test::RunIgnored::No },
         format: if config.quiet { test::OutputFormat::Terse } else { test::OutputFormat::Pretty },
         logfile: config.logfile.clone(),
@@ -123,6 +133,8 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         skip: vec![],
         list: false,
         options: test::Options::new(),
+        #[cfg(feature = "rustc")]
+        time_options: None,
     }
 }
 
@@ -254,6 +266,8 @@ pub fn make_test(config: &Config, testpaths: &TestPaths) -> test::TestDescAndFn 
             ignore: early_props.ignore,
             should_panic: should_panic,
             allow_fail: false,
+            #[cfg(feature = "rustc")]
+            test_type: test::TestType::IntegrationTest,
         },
         testfn: make_test_closure(config, testpaths),
     }

--- a/src/runtest.rs
+++ b/src/runtest.rs
@@ -266,12 +266,12 @@ impl<'test> TestCx<'test> {
         }
     }
 
-    #[cfg(feature = "stable")]
+    #[cfg(not(feature = "rustc"))]
     fn run_pretty_test(&self) {
         self.fatal("pretty-printing tests can only be used with nightly Rust".into());
     }
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "rustc")]
     fn run_pretty_test(&self) {
         if self.props.pp_exact.is_some() {
             logv(self.config, "testing for exact pretty-printing".to_owned());
@@ -348,7 +348,7 @@ impl<'test> TestCx<'test> {
         }
     }
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "rustc")]
     fn print_source(&self, src: String, pretty_type: &str) -> ProcRes {
         let aux_dir = self.aux_output_dir_name();
 
@@ -367,7 +367,7 @@ impl<'test> TestCx<'test> {
                              Some(src))
     }
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "rustc")]
     fn compare_source(&self,
                       expected: &str,
                       actual: &str) {
@@ -388,7 +388,7 @@ actual:\n\
         }
     }
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "rustc")]
     fn typecheck_source(&self, src: String) -> ProcRes {
         let mut rustc = Command::new(&self.config.rustc_path);
 


### PR DESCRIPTION
Currently, `tester` crate is used in stable, beta, and nightly as well.
But on nightly, we should use Rust's builtin `test` crate.
#200 made this breakage.
Also, this contains the fix for the latest rustc breakage.