### PR TITLE
Update `tester` dependency to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 rustfix = "0.4.1"
-tester = "0.6"
+tester = "0.7"
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 #![crate_type = "lib"]
 
 #![cfg_attr(feature = "rustc", feature(rustc_private))]
+#![cfg_attr(feature = "rustc", feature(test))]
 
 #![deny(unused_imports)]
 
@@ -19,7 +20,10 @@ extern crate rustc;
 
 #[cfg(unix)]
 extern crate libc;
+#[cfg(feature = "rustc")]
 extern crate test;
+#[cfg(not(feature = "rustc"))]
+extern crate tester as test;
 
 #[cfg(feature = "tmp")] extern crate tempfile;
 


### PR DESCRIPTION
`tester` 0.7.0 renamed lib name from `test` to just `tester`.