### PR TITLE
Bump to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiletest_rs"
-version = "0.3.26"
+version = "0.4.0"
 authors = [ "The Rust Project Developers"
           , "Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>"
           , "Manish Goregaokar <manishsmail@gmail.com>"


### PR DESCRIPTION
Breaking change since it pulls in https://github.com/laumann/compiletest-rs/pull/208 , which is part of the public API.