### PR TITLE
Bump rustfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tempfile = { version = "3.0", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-rustfix = "0.4.1"
+rustfix = "0.5"
 tester = "0.7"
 
 [target."cfg(unix)".dependencies]


### PR DESCRIPTION
Workarounds https://github.com/rust-lang-nursery/failure/issues/342 by getting rid of `failure`.