### PR TITLE
Fix failing test

### DIFF
--- a/test-project/tests/compile-fail/asm-gated.rs
+++ b/test-project/tests/compile-fail/asm-gated.rs
@@ -10,6 +10,6 @@
 
 fn main() {
     unsafe {
-        asm!(""); //~ ERROR inline assembly is not stable enough
+        llvm_asm!(""); //~ ERROR inline assembly is not stable enough
     }
 }


### PR DESCRIPTION
`asm!(..)` has changed to `llvm_asm!(..)` on nightly and beta.