### PR TITLE
Update `tester` dependency to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 rustfix = "0.5"
-tester = "0.7"
+tester = "0.8"
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"


### PR DESCRIPTION
https://github.com/messense/rustc-test/commit/1c01e1d478cb634adcfead7eb6fe083b884bbba7

Updated to rust-lang/rust@a68864b