### PR TITLE
Run `cargo test` on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ matrix:
    - rust: nightly
      env: FEATURES=""
 
-script: cd test-project && cargo test $FEATURES
+script:
+  - cargo test $FEATURES
+  - cd test-project && cargo test $FEATURES
 
 notifications:
   email:


### PR DESCRIPTION
There is currently one unit test which wasn't executed on CI before.
This makes it so that all the normal tests will get executed as well.