### PR TITLE
Add basic `bless` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 rustfix = "0.5"
-tester = "0.8"
+tester = "0.9"
 lazy_static = "1.4"
 
 [target."cfg(unix)".dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 rustfix = "0.5"
 tester = "0.8"
+lazy_static = "1.4"
 
 [target."cfg(unix)".dependencies]
 libc = "0.2"

--- a/src/common.rs
+++ b/src/common.rs
@@ -148,8 +148,8 @@ pub struct Config {
     /// Run ignored tests
     pub run_ignored: bool,
 
-    /// Only run tests that match this filter
-    pub filter: Option<String>,
+    /// Only run tests that match these filters
+    pub filters: Vec<String>,
 
     /// Exactly match the filter, rather than a substring
     pub filter_exact: bool,
@@ -372,7 +372,7 @@ impl Default for Config {
             stage_id: "stage-id".to_owned(),
             mode: Mode::RunPass,
             run_ignored: false,
-            filter: None,
+            filters: vec![],
             filter_exact: false,
             logfile: None,
             runtool: None,

--- a/src/common.rs
+++ b/src/common.rs
@@ -102,6 +102,9 @@ impl fmt::Display for Mode {
 
 #[derive(Clone)]
 pub struct Config {
+    /// `true` to overwrite stderr/stdout/fixed files instead of complaining about changes in output.
+    pub bless: bool,
+
     /// The library paths required for running the compiler
     pub compile_lib_path: PathBuf,
 
@@ -239,6 +242,25 @@ pub struct TestPaths {
     pub relative_dir: PathBuf, // e.g., foo/bar
 }
 
+/// Used by `ui` tests to generate things like `foo.stderr` from `foo.rs`.
+pub fn expected_output_path(
+    testpaths: &TestPaths,
+    revision: Option<&str>,
+    kind: &str,
+) -> PathBuf {
+    assert!(UI_EXTENSIONS.contains(&kind));
+    let mut parts = Vec::new();
+
+    if let Some(x) = revision {
+        parts.push(x);
+    }
+    parts.push(kind);
+
+    let extension = parts.join(".");
+    testpaths.file.with_extension(extension)
+}
+
+pub const UI_EXTENSIONS: &[&str] = &[UI_STDERR, UI_STDOUT, UI_FIXED];
 pub const UI_STDERR: &str = "stderr";
 pub const UI_STDOUT: &str = "stdout";
 pub const UI_FIXED: &str = "fixed";
@@ -335,6 +357,7 @@ impl Default for Config {
         let platform = rustc_session::config::host_triple().to_string();
 
         Config {
+            bless: false,
             compile_lib_path: PathBuf::from(""),
             run_lib_path: PathBuf::from(""),
             rustc_path: PathBuf::from("rustc"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub fn run_tests(config: &Config) {
 
 pub fn test_opts(config: &Config) -> test::TestOpts {
     test::TestOpts {
-        filter: config.filter.clone(),
+        filters: config.filters.clone(),
         filter_exact: config.filter_exact,
         exclude_should_panic: false,
         force_run_in_process: false,

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,8 @@
 
 use std::env;
 use common::Config;
+use std::ffi::OsStr;
+use std::path::PathBuf;
 
 /// Conversion table from triple OS name to Rust SYSNAME
 const OS_TABLE: &'static [(&'static str, &'static str)] = &[
@@ -106,5 +108,25 @@ pub fn logv(config: &Config, s: String) {
     debug!("{}", s);
     if config.verbose {
         println!("{}", s);
+    }
+}
+
+pub trait PathBufExt {
+    /// Append an extension to the path, even if it already has one.
+    fn with_extra_extension<S: AsRef<OsStr>>(&self, extension: S) -> PathBuf;
+}
+
+impl PathBufExt for PathBuf {
+    fn with_extra_extension<S: AsRef<OsStr>>(&self, extension: S) -> PathBuf {
+        if extension.as_ref().is_empty() {
+            self.clone()
+        } else {
+            let mut fname = self.file_name().unwrap().to_os_string();
+            if !extension.as_ref().to_str().unwrap().starts_with('.') {
+                fname.push(".");
+            }
+            fname.push(extension);
+            self.with_file_name(fname)
+        }
     }
 }

--- a/tests/bless.rs
+++ b/tests/bless.rs
@@ -1,0 +1,85 @@
+//! Tests for the `bless` option
+
+extern crate compiletest_rs as compiletest;
+
+mod test_support;
+use test_support::{testsuite, TestsuiteBuilder, GLOBAL_ROOT};
+use compiletest::Config;
+
+fn setup(mode: &str) -> (Config, TestsuiteBuilder) {
+    let builder = testsuite(mode);
+    let mut config = Config::default();
+    let cfg_mode = mode.parse().expect("Invalid mode");
+    config.mode = cfg_mode;
+    config.src_base = builder.root.clone();
+    config.build_base = GLOBAL_ROOT.join("build_base");
+
+    (config, builder)
+}
+
+#[test]
+fn test_bless_new_file() {
+    let (mut config, builder) = setup("ui");
+    config.bless = true;
+
+    builder.mk_file(
+              "foobar.rs",
+              r#"
+                  #[warn(unused_variables)]
+                  fn main() {
+                      let abc = "foobar";
+                  }
+              "#,
+          );
+    compiletest::run_tests(&config);
+
+    // Blessing should cause the stderr to be created directly
+    assert!(builder.file_contents("foobar.stderr").contains("unused variable"));
+
+    // And a second run of the tests, with blessing disabled should work just fine
+    config.bless = false;
+    compiletest::run_tests(&config);
+}
+
+#[test]
+fn test_bless_update_file() {
+    let (mut config, builder) = setup("ui");
+    config.bless = true;
+
+    builder.mk_file(
+        "foobar2.rs",
+        r#"
+            #[warn(unused_variables)]
+            fn main() {
+                let abc = "foobar_update";
+            }
+        "#,
+    );
+    builder.mk_file(
+        "foobar2.stderr",
+        r#"
+            warning: unused variable: `abc`
+             --> $DIR/foobar2.rs:4:27
+              |
+            4 |                       let abc = "foobar";
+              |                           ^^^ help: if this is intentional, prefix it with an underscore: `_abc`
+              |
+            note: the lint level is defined here
+             --> $DIR/foobar2.rs:2:26
+              |
+            2 |                   #[warn(unused_variables)]
+              |                          ^^^^^^^^^^^^^^^^
+
+            warning: 1 warning emitted
+        "#,
+    );
+    compiletest::run_tests(&config);
+
+    // Blessing should cause the stderr to be created directly
+    assert!(builder.file_contents("foobar2.stderr").contains("unused variable"));
+    assert!(builder.file_contents("foobar2.stderr").contains("foobar_update"));
+
+    // And a second run of the tests, with blessing disabled should work just fine
+    config.bless = false;
+    compiletest::run_tests(&config);
+}

--- a/tests/test_support/mod.rs
+++ b/tests/test_support/mod.rs
@@ -1,0 +1,105 @@
+//! Provides a simple way to set up compiletest sample testsuites used in testing.
+//!
+//! Inspired by cargo's `cargo-test-support` crate:
+//! https://github.com/rust-lang/cargo/tree/master/crates/cargo-test-support
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+
+static COMPILETEST_INTEGRATION_TEST_DIR: &str = "cit";
+
+thread_local! {
+    static TEST_ID: RefCell<Option<usize>> = RefCell::new(None);
+}
+
+lazy_static::lazy_static! {
+    pub static ref GLOBAL_ROOT: PathBuf = {
+        let mut path = env::current_exe().unwrap();
+        path.pop(); // chop off exe name
+        path.pop(); // chop off 'deps' part
+        path.pop(); // chop off 'debug'
+
+        path.push(COMPILETEST_INTEGRATION_TEST_DIR);
+        path.mkdir_p();
+        path
+    };
+}
+
+pub fn testsuite(mode: &str) -> TestsuiteBuilder {
+    let builder = TestsuiteBuilder::new(mode);
+    builder.build();
+    builder
+}
+
+pub struct TestsuiteBuilder {
+    pub root: PathBuf,
+}
+
+impl TestsuiteBuilder {
+    pub fn new(mode: &str) -> Self {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        TEST_ID.with(|n| *n.borrow_mut() = Some(id));
+        let root = GLOBAL_ROOT.join(format!("id{}", TEST_ID.with(|n|n.borrow().unwrap()))).join(mode);
+        root.mkdir_p();
+
+        Self {
+            root,
+        }
+    }
+
+
+    /// Creates a new file to be used for the integration test
+    pub fn mk_file(&self, path: &str, body: &str) {
+        self.root.mkdir_p();
+        fs::write(self.root.join(&path), &body)
+            .unwrap_or_else(|e| panic!("could not create file {}: {}", path, e));
+    }
+
+    /// Returns the contents of the file
+    pub fn file_contents(&self, name: &str) -> String {
+        fs::read_to_string(self.root.join(name)).expect("Unable to read file")
+    }
+
+    // Sets up a new testsuite root directory
+    fn build(&self) {
+        // Cleanup before we run the next test
+        self.rm_root();
+
+        // Create the new directory
+        self.root.mkdir_p();
+    }
+
+    /// Deletes the root directory and all its contents
+    fn rm_root(&self) {
+        self.root.rm_rf();
+    }
+}
+
+pub trait PathExt {
+    fn rm_rf(&self);
+    fn mkdir_p(&self);
+}
+
+impl PathExt for Path {
+    fn rm_rf(&self) {
+        if self.is_dir() {
+            if let Err(e) = fs::remove_dir_all(self) {
+                panic!("failed to remove {:?}: {:?}", self, e)
+            }
+        } else {
+            if let Err(e) = fs::remove_file(self) {
+                panic!("failed to remove {:?}: {:?}", self, e)
+            }
+        }
+    }
+
+    fn mkdir_p(&self) {
+        fs::create_dir_all(self)
+            .unwrap_or_else(|e| panic!("failed to mkdir_p {}: {}", self.display(), e))
+    }
+}


### PR DESCRIPTION
This adds basic `bless` support. Unfortunately without support for `miri` because I wasn't able to untangle it properly so far.

Should be merged after #232 